### PR TITLE
fix config error when not specified

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -38,6 +38,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
                 ->arrayNode('class')
+                    ->addDefaultsIfNotSet()
                     ->children()
                         ->scalarNode('page')->defaultValue('Application\\Networking\\InitCmsBundle\\Entity\\Page')->end()
                         ->scalarNode('layout_block')->defaultValue('Networking\\InitCmsBundle\\Entity\\LayoutBlock')->end()


### PR DESCRIPTION
If  `class` is not set in config, default values are not used and generate lot of notice in  `NetworkingInitCmsExtension::registerDoctrineORMMapping()`
