### PR TITLE
fix path to jquery

### DIFF
--- a/Resources/views/admin_base.html.twig
+++ b/Resources/views/admin_base.html.twig
@@ -30,7 +30,7 @@ file that was distributed with this source code.
 
     {% block javascripts %}
         {% javascripts filter="?yui_js"
-        '@SonatajQueryBundle/Resources/public/jquery-1.8.3.js'
+        '@SonatajQueryBundle/Resources/public/jquery-1.8.0.js'
         '@SonatajQueryBundle/Resources/public/jquery-ui-1.8.23.js'
         '@SonatajQueryBundle/Resources/public/jquery-ui-i18n.js'
         output='js/head_admin.js' %}


### PR DESCRIPTION
this is the correct version of jquery to use as defined in the latest branch of SonataJqueryBundle.
https://github.com/sonata-project/SonatajQueryBundle/tree/master/Resources/public
