### PR TITLE
Fix GalleryAdmin pagination links

### DIFF
--- a/Resources/views/GalleryAdmin/list.html.twig
+++ b/Resources/views/GalleryAdmin/list.html.twig
@@ -110,51 +110,51 @@ file that was distributed with this source code.
                                     </tfoot>
                                 {% endblock %}
                             </table>
-                            {% if admin.datagrid.pager.haveToPaginate() %}
+                            {% if datagrid.pager.haveToPaginate() %}
                                 <div class="row">
                                     <div class="col-xs-1">
                                         <div class="clearfix">&nbsp;</div>
-                                        {{ admin.datagrid.pager.page }} / {{ admin.datagrid.pager.lastpage }}</div>
+                                        {{ datagrid.pager.page }} / {{ datagrid.pager.lastpage }}</div>
                                     <div class="col-xs-10 text-center">
                                         <ul class="pagination pagination-sm">
 
-                                            {% if admin.datagrid.pager.page != 1 %}
+                                            {% if datagrid.pager.page != 1 %}
                                                 <li>
-                                                    <a href="{{ admin.generateUrl('list', admin.modelmanager.paginationparameters(admin.datagrid, 1)) }}"
+                                                    <a href="{{ admin.generateUrl('list', admin.modelmanager.paginationparameters(datagrid, 1)) }}"
                                                        title="{{ 'link_first_pager'|trans({}, 'SonataAdminBundle') }}">&laquo;</a>
                                                 </li>
                                             {% endif %}
 
-                                            {% if admin.datagrid.pager.page != admin.datagrid.pager.previouspage %}
+                                            {% if datagrid.pager.page != datagrid.pager.previouspage %}
                                                 <li>
-                                                    <a href="{{ admin.generateUrl('list', admin.modelmanager.paginationparameters(admin.datagrid, admin.datagrid.pager.previouspage)) }}"
+                                                    <a href="{{ admin.generateUrl('list', admin.modelmanager.paginationparameters(datagrid, datagrid.pager.previouspage)) }}"
                                                        title="{{ 'link_previous_pager'|trans({}, 'SonataAdminBundle') }}">&lsaquo;</a>
                                                 </li>
                                             {% endif %}
 
                                             {# Set the number of pages to display in the pager #}
-                                            {% for page in admin.datagrid.pager.getLinks() %}
-                                                {% if page == admin.datagrid.pager.page %}
+                                            {% for page in datagrid.pager.getLinks() %}
+                                                {% if page == datagrid.pager.page %}
                                                     <li class="active"><a
-                                                                href="{{ admin.generateUrl('list', admin.modelmanager.paginationparameters(admin.datagrid, page)) }}">{{ page }}</a>
+                                                                href="{{ admin.generateUrl('list', admin.modelmanager.paginationparameters(datagrid, page)) }}">{{ page }}</a>
                                                     </li>
                                                 {% else %}
                                                     <li>
-                                                        <a href="{{ admin.generateUrl('list', admin.modelmanager.paginationparameters(admin.datagrid, page)) }}">{{ page }}</a>
+                                                        <a href="{{ admin.generateUrl('list', admin.modelmanager.paginationparameters(datagrid, page)) }}">{{ page }}</a>
                                                     </li>
                                                 {% endif %}
                                             {% endfor %}
 
-                                            {% if admin.datagrid.pager.page != admin.datagrid.pager.nextpage %}
+                                            {% if datagrid.pager.page != datagrid.pager.nextpage %}
                                                 <li>
-                                                    <a href="{{ admin.generateUrl('list', admin.modelmanager.paginationparameters(admin.datagrid, admin.datagrid.pager.nextpage)) }}"
+                                                    <a href="{{ admin.generateUrl('list', admin.modelmanager.paginationparameters(datagrid, datagrid.pager.nextpage)) }}"
                                                        title="{{ 'link_next_pager'|trans({}, 'SonataAdminBundle') }}">&rsaquo;</a>
                                                 </li>
                                             {% endif %}
 
-                                            {% if admin.datagrid.pager.page != admin.datagrid.pager.lastpage %}
+                                            {% if datagrid.pager.page != datagrid.pager.lastpage %}
                                                 <li>
-                                                    <a href="{{ admin.generateUrl('list', admin.modelmanager.paginationparameters(admin.datagrid, admin.datagrid.pager.lastpage)) }}"
+                                                    <a href="{{ admin.generateUrl('list', admin.modelmanager.paginationparameters(datagrid, datagrid.pager.lastpage)) }}"
                                                        title="{{ 'link_last_pager'|trans({}, 'SonataAdminBundle') }}">&raquo;</a>
                                                 </li>
                                             {% endif %}
@@ -200,7 +200,7 @@ file that was distributed with this source code.
         {% set name = persistent_parameters.context ? persistent_parameters.context: 'default' %}
         {% if datagrid.filters %}
             <form action="{{ admin.generateUrl('list') }}" method="GET"
-                  class="sonata-filter-form {{ admin.isChild and 1 == admin.datagrid.filters|length ? 'hide' : '' }}form-horizontal filters menu-filter">
+                  class="sonata-filter-form {{ admin.isChild and 1 == datagrid.filters|length ? 'hide' : '' }}form-horizontal filters menu-filter">
 
                 <input type="hidden" name="context" value="{{ persistent_parameters.context }}"/>
                 {% if persistent_parameters.provider is defined %}


### PR DESCRIPTION
Hello,

By calling `admin.datagrid` in the template you get a just initialized datagrid with a "blank" pager, so the pagination links are never displayed.

Instead, we must use the datagrid passed to the template by the controller.
