### PR TITLE
Fix sonata retrieve form element

### DIFF
--- a/Resources/views/CRUD/edit_orm_many_association_script.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_association_script.html.twig
@@ -144,14 +144,18 @@ var field_dialog_form_action_{{ id }} = function (event) {
 
                 // reload the form element
                 jQuery('#field_widget_{{ id }}').closest('form').ajaxSubmit({
-                    url: '{{ url('sonata_admin_retrieve_form_element', {
+                    {% set params = {
                                 'elementId': id,
                                 'subclass':  sonata_admin.admin.getActiveSubclassCode(),
                                 'objectId':  sonata_admin.admin.root.id(sonata_admin.admin.root.subject),
                                 'uniqid':    sonata_admin.admin.root.uniqid,
                                 'code':      sonata_admin.admin.root.code,
                                 'locale':    app.request.locale
-                            }) }}',
+                            } %}
+                    {% if app.request.query.has('provider') %}
+                        {% set params = params|merge({'provider': app.request.query.get('provider')}) %}
+                    {% endif %}
+                    url: '{{ url('sonata_admin_retrieve_form_element', params) }}',
                     data: {_xml_http_request: true},
                     type: 'POST',
                     success: function (html) {


### PR DESCRIPTION
Hi,

This fix resend the `provider` query param if present in the ajax callback called to retrieve the updated form element in a Tag creation modal.

Steps to reproduce the bugfix : 

* Add new Gallery
* Add a new line of GalleryHasMedia
* Click on "Add new" to add a Media
* In the modal, Click on "Add new" for the Tag
* Fill and Submit.

Instead of the refreshed form element, you should have a `RunTimeException` with the message `unable to retrieve the provider named : ''`

I wished there was a better way than this solution, maybe you'll have one, but it works.