### PR TITLE
Move from IvoryCKEditorBundle to FOSCKEditorBundle

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -61,7 +61,7 @@ Add the following lines (plus your own bundles) to your application kernel
                     new Sonata\MediaBundle\SonataMediaBundle(),
                     new Sonata\CoreBundle\SonataCoreBundle(),
                     new Knp\Bundle\MarkdownBundle\KnpMarkdownBundle(),
-                    new Ivory\CKEditorBundle\IvoryCKEditorBundle(),
+                    new FOS\CKEditorBundle\FOSCKEditorBundle(),
                     new Sonata\FormatterBundle\SonataFormatterBundle(),
                     new \Sonata\IntlBundle\SonataIntlBundle(),
                     new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),

--- a/src/Admin/Model/HelpTextAdmin.php
+++ b/src/Admin/Model/HelpTextAdmin.php
@@ -9,7 +9,7 @@
  */
 namespace Networking\InitCmsBundle\Admin\Model;
 
-use Ivory\CKEditorBundle\Form\Type\CKEditorType;
+use FOS\CKEditorBundle\Form\Type\CKEditorType;
 use Networking\InitCmsBundle\Admin\BaseAdmin;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;

--- a/src/Model/Text.php
+++ b/src/Model/Text.php
@@ -30,7 +30,7 @@ abstract class Text implements ContentInterface, TextInterface
      * @var string $content
      * @Sonata\FormMapper(
      *      name="text",
-     *      type="Ivory\CKEditorBundle\Form\Type\CKEditorType",
+     *      type="FOS\CKEditorBundle\Form\Type\CKEditorType",
      *      options={
      *          "label_render" = false,
      *          "horizontal_input_wrapper_class" = "col-md-12",

--- a/src/Resources/config/cms/cms_config.yml
+++ b/src/Resources/config/cms/cms_config.yml
@@ -11,5 +11,5 @@ imports:
     - { resource: "@NetworkingInitCmsBundle/Resources/config/cms/jms_serializer.yml" }
     - { resource: "@NetworkingInitCmsBundle/Resources/config/cms/lexik_translation.yml" }
     - { resource: "@NetworkingInitCmsBundle/Resources/config/cms/ibrows_sonata_translation.yml" }
-    - { resource: "@NetworkingInitCmsBundle/Resources/config/cms/ivory_ck_editor.yml" }
+    - { resource: "@NetworkingInitCmsBundle/Resources/config/cms/fos_ck_editor.yml" }
     - { resource: "@NetworkingInitCmsBundle/Resources/config/cms/oneuploader.yml" }

--- a/src/Resources/config/cms/fos_ck_editor.yml
+++ b/src/Resources/config/cms/fos_ck_editor.yml
@@ -1,4 +1,4 @@
-ivory_ck_editor:
+fos_ck_editor:
     default_config: init_cms
     configs:
         init_cms:

--- a/src/Resources/views/PageAdmin/page_edit.html.twig
+++ b/src/Resources/views/PageAdmin/page_edit.html.twig
@@ -67,8 +67,8 @@ file that was distributed with this source code.
 {% block before_body_end %}
     {{ parent() }}
         <script type="text/javascript">
-            var CKEDITOR_BASEPATH = "{{ ckeditor_base_path('bundles/ivoryckeditor/') }}";
+            var CKEDITOR_BASEPATH = "{{ ckeditor_base_path('bundles/fosckeditor/') }}";
         </script>
-        <script type="text/javascript" src="{{ ckeditor_js_path('bundles/ivoryckeditor/ckeditor.js') }}"></script>
+        <script type="text/javascript" src="{{ ckeditor_js_path('bundles/fosckeditor/ckeditor.js') }}"></script>
 {% endblock %}
 

--- a/src/Twig/Extension/NetworkingHelperExtension.php
+++ b/src/Twig/Extension/NetworkingHelperExtension.php
@@ -11,7 +11,7 @@
 namespace Networking\InitCmsBundle\Twig\Extension;
 
 use Doctrine\ORM\EntityRepository;
-use Ivory\CKEditorBundle\Model\ConfigManager;
+use FOS\CKEditorBundle\Model\ConfigManager;
 use JMS\Serializer\SerializerInterface;
 use Networking\InitCmsBundle\Admin\Model\LayoutBlockAdmin;
 use Networking\InitCmsBundle\Form\Type\AutocompleteType;


### PR DESCRIPTION
Hi,

We took over [IvoryCKEditorBundle](https://github.com/egeloen/IvoryCKEditorBundle) and now it is under [FriendsOfSymfony](https://github.com/FriendsOfSymfony) wing and it is renamed to [FOSCKEditorBundle](https://github.com/FriendsOfSymfony/FOSCKEditorBundle).

We are helping active libraries that are depending on `IvoryCKEditorBundle` migrate to `FOSCKEditorBundle`.

The Bundle will be released in the next few days, do not merge until the bundle gets released so we can change the version in the composer.

Thank you for your time.