### PR TITLE
Update oneup/uploader-bundle to 2.1.6 (security release)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "knplabs/knp-paginator-bundle": "^4.0",
         "lexik/translation-bundle": "*",
         "oneup/flysystem-bundle": "^3.0",
-        "oneup/uploader-bundle": "^2.1",
+        "oneup/uploader-bundle": "^2.1.6",
         "phpfastcache/phpfastcache": "^3.0",
         "mopa/bootstrap-bundle": "^3.3",
         "sensio/framework-extra-bundle": "^5.1",


### PR DESCRIPTION
Relative Path Traversal (CWE-23) in chunked uploads. See more here: https://github.com/1up-lab/OneupUploaderBundle/security/advisories/GHSA-x8wj-6m73-gfqp.