### PR TITLE
Update oneup/uploader-bundle to 1.9.4 (security release)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "incenteev/composer-parameter-handler": "^2.0",
         "jms/serializer-bundle": "^2.0",
         "knplabs/knp-paginator-bundle": "^2.7",
-        "oneup/uploader-bundle": "^1.9",
+        "oneup/uploader-bundle": "^1.9.4",
         "phpfastcache/phpfastcache": "^3.0",
         "mopa/bootstrap-bundle": "^3.2",
         "sensio/distribution-bundle": "^5.0.19",


### PR DESCRIPTION
Relative Path Traversal (CWE-23) in chunked uploads. See more here: https://github.com/1up-lab/OneupUploaderBundle/security/advisories/GHSA-x8wj-6m73-gfqp.